### PR TITLE
Fix typo in rOpenSci name

### DIFF
--- a/.github/ISSUE_TEMPLATE/A-submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/A-submit-software-for-review.md
@@ -88,4 +88,4 @@ Confirm each of the following by checking the box.  This package:
 
 ## Code of conduct
 
-- [ ] I agree to abide by [ROpenSci's Code of Conduct](https://ropensci.github.io/dev_guide/policies.html#code-of-conduct) during the review process and in maintaining my package should it be accepted.
+- [ ] I agree to abide by [rOpenSci's Code of Conduct](https://ropensci.github.io/dev_guide/policies.html#code-of-conduct) during the review process and in maintaining my package should it be accepted.


### PR DESCRIPTION
As it is always a struggle for me to properly write rOpenSci, I noticed a small typo in the issue template for submission. It's just for the sake of consistency ;)