### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: numfocus
+custom: https://numfocus.org/donate-to-ropensci


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature launched today at GitHub Universe!

I've also included a custom link to the donation form specifically for rOpenSci. More info can be found here: https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository

cc @karthik