### PR TITLE
Remove deprecated database access scope option.

### DIFF
--- a/.github/ISSUE_TEMPLATE/A-submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/A-submit-software-for-review.md
@@ -28,7 +28,6 @@ Version accepted: TBD
 
 	- [ ] data retrieval
 	- [ ] data extraction
-	- [ ] database access
 	- [ ] data munging
 	- [ ] data deposition
 	- [ ] workflow automataion


### PR DESCRIPTION
I believe this category has been split up and is not part of the [package categories](https://devguide.ropensci.org/policies.html#package-categories) in the dev guide anymore.