### PR TITLE
add submission-type variable to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/A-submit-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/A-submit-software-for-review.md
@@ -9,6 +9,7 @@ Submitting Author: <!--author1-->Name (@github_handle)<!--end-author1-->
 Other Package Authors: (delete if none) <!--author-others-->Name (@github_handle)<!--end-author-others-->
 Repository:  <!--repourl--><!--end-repourl-->
 Version submitted:
+Submission type: <!--submission-type-->Standard<!--end-submission-type-->
 Editor: <!--editor--> TBD <!--end-editor-->
 Reviewers: <!--reviewers-list--> TBD <!--end-reviewers-list-->
 <!--due-dates-list--><!--end-due-dates-list-->

--- a/.github/ISSUE_TEMPLATE/B-submit-a-presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/B-submit-a-presubmission-inquiry.md
@@ -8,7 +8,8 @@ about: Not sure your software fits? Use this template to get a quick response fr
 
 Submitting Author: Name (@github_handle)  
 Other Package Authors: (delete if none) Name (@github_handle)
-Repository:   
+Repository:  <!--repourl--><!--end-repourl-->
+Submission type: <!--submission-type-->Pre-submission<!--end-submission-type-->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/D-enviar-software-para-revision.md
+++ b/.github/ISSUE_TEMPLATE/D-enviar-software-para-revision.md
@@ -8,6 +8,7 @@ Persona Encargada: <!--author1-->nombre (@github_handle)<!--end-author1-->
 Otras Autoras del Paquete: (borra si solo hay una autora) <!--author-others-->nombre (@github_handle)<!--end-author-others-->
 Repositorio: <!--repourl--><!--end-repourl-->
 Versión Enviada:
+Typo de Envio: <!--submission-type-->Estándar<!--end-submission-type-->
 Editora: <!--editor--> TBD <!--end-editor-->
 Revisores: <!--reviewers-list--> TBD <!--end-reviewers-list-->
 <!--due-dates-list--><!--end-due-dates-list-->

--- a/.github/ISSUE_TEMPLATE/D-enviar-software-para-revision.md
+++ b/.github/ISSUE_TEMPLATE/D-enviar-software-para-revision.md
@@ -8,7 +8,7 @@ Persona Encargada: <!--author1-->nombre (@github_handle)<!--end-author1-->
 Otras Autoras del Paquete: (borra si solo hay una autora) <!--author-others-->nombre (@github_handle)<!--end-author-others-->
 Repositorio: <!--repourl--><!--end-repourl-->
 Versión Enviada:
-Typo de Envio: <!--submission-type-->Estándar<!--end-submission-type-->
+Tipo de Envio: <!--submission-type-->Estándar<!--end-submission-type-->
 Editora: <!--editor--> TBD <!--end-editor-->
 Revisores: <!--reviewers-list--> TBD <!--end-reviewers-list-->
 <!--due-dates-list--><!--end-due-dates-list-->

--- a/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
+++ b/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
@@ -6,7 +6,8 @@ about: ¿Quieres confirmar que tu paquete encaja para revisión? Usa esta planti
 
 Persona Encargada: nombre (@github_handle)  
 Otras Autoras del Paquete: (borra si solo hay una autora) nombre (@github_handle)
-Repositorio:   
+Repositorio: <!--repourl--><!--end-repourl-->
+Typo de Envio: <!--submission-type-->pre-Envio<!--end-submission-type-->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
+++ b/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
@@ -7,7 +7,7 @@ about: ¿Quieres confirmar que tu paquete encaja para revisión? Usa esta planti
 Persona Encargada: nombre (@github_handle)  
 Otras Autoras del Paquete: (borra si solo hay una autora) nombre (@github_handle)
 Repositorio: <!--repourl--><!--end-repourl-->
-Typo de Envio: <!--submission-type-->pre-Envio<!--end-submission-type-->
+Typo de Envio: <!--submission-type-->pre-envio<!--end-submission-type-->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
+++ b/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
@@ -7,7 +7,7 @@ about: ¿Quieres confirmar que tu paquete encaja para revisión? Usa esta planti
 Persona Encargada: nombre (@github_handle)  
 Otras Autoras del Paquete: (borra si solo hay una autora) nombre (@github_handle)
 Repositorio: <!--repourl--><!--end-repourl-->
-Typo de Envio: <!--submission-type-->pre-envio<!--end-submission-type-->
+Tipo de Envio: <!--submission-type-->pre-envio<!--end-submission-type-->
 
 ---
 


### PR DESCRIPTION
@noamross @maelle This provides the `submission-type` variable that the bot can use to activate different responders, via branc new [`if: value_equals`](https://buffy.readthedocs.io/en/latest/configuration.html#common-options) option thanks to @xuanxu.