### PR TITLE
Stats badge

### DIFF
--- a/.github/ISSUE_TEMPLATE/F-submit-statistical-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/F-submit-statistical-software-for-review.md
@@ -10,6 +10,7 @@ Other Package Authors: (delete if none) Name (@github_handle)
 Repository:  <!--repourl--><!--end-repourl-->
 Version submitted:
 Submission type: <!--submission-type-->Stats<!--end-submission-type-->
+Badge grade: <!--statsgrade-->bronze/silver/gold (select one)<!--end-statsgrade-->
 Editor: <!--editor--> TBD <!--end-editor-->
 Reviewers: <!--reviewers-list--> TBD <!--end-reviewers-list-->
 <!--due-dates-list--><!--end-due-dates-list-->

--- a/README.Rmd
+++ b/README.Rmd
@@ -101,6 +101,16 @@ rOpenSci's Software Peer Review process is run by:
 * [Julia Gustavsen](https://github.com/jooolia), Agroscope
 * [Emily Riederer](https://github.com/emilyriederer), Capital One 
 
+Associate editors for statistical software are:
+
+- [Ben Bolker](https://github.com/bbolker), McMaster University, Canada
+- [Rebecca Killick](https://github.com/rkillick), Lancaster University, UK
+- [Stephanie Hicks](https://github.com/stephaniehicks), Johns Hopkins University, USA
+- [Paula Moraga](https://github.com/Paula-Moraga), King Abdullah University of Science and Technology, Saudi Arabia
+- [Leonardo Collado-Torres](https://github.com/lcolladotor), Lieber Institute for Brain Development, USA
+- [Toby Hocking](https://github.com/tdhock), Northern Arizona University, USA
+
+
 ### Reviewers and guest editors
 
 We are grateful to the following individuals who have offered up their time and expertise to review packages submitted to rOpenSci.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ rOpenSci’s Software Peer Review process is run by:
   - [Mauro Lepore](https://github.com/maurolepore), 2 Degrees Investing
     Initiative
   - [Laura DeCicco](https://github.com/ldecicco-USGS), USGS
-  - [Julia Gustavsen](https://github.com/jooolia), SOPHiA GENETICS
+  - [Julia Gustavsen](https://github.com/jooolia), Agroscope
   - [Emily Riederer](https://github.com/emilyriederer), Capital One
 
 ### Reviewers and guest editors

--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ rOpenSci’s Software Peer Review process is run by:
   - [Julia Gustavsen](https://github.com/jooolia), Agroscope
   - [Emily Riederer](https://github.com/emilyriederer), Capital One
 
+Associate editors for statistical software are:
+
+- [Ben Bolker](https://github.com/bbolker), McMaster University, Canada
+- [Rebecca Killick](https://github.com/rkillick), Lancaster University, UK
+- [Stephanie Hicks](https://github.com/stephaniehicks), Johns Hopkins University, USA
+- [Paula Moraga](https://github.com/Paula-Moraga), King Abdullah University of Science and Technology, Saudi Arabia
+- [Leonardo Collado-Torres](https://github.com/lcolladotor), Lieber Institute for Brain Development, USA
+- [Toby Hocking](https://github.com/tdhock), Northern Arizona University, USA
+
+
 ### Reviewers and guest editors
 
 We are grateful to the following individuals who have offered up their


### PR DESCRIPTION
This should be good to merge. It is the variable used in the new `@ropensci-review-bot mint` commands, and also in the [`roreviewapi::stats_badge()` command](https://github.com/ropensci-review-tools/roreviewapi/blob/main/R/srr.R).