### PR TITLE
Clarify what to write in NEWS.md

### DIFF
--- a/.buffy/templates/approved.md
+++ b/.buffy/templates/approved.md
@@ -11,7 +11,7 @@ To-dos:
     * replace your package docs URL with `https://docs.ropensci.org/package_name`
     * In addition, in your DESCRIPTION file, include the docs link in the `URL` field alongside the link to the GitHub repository, e.g.: `URL: https://docs.ropensci.org/foobar (website) https://github.com/ropensci/foobar`
 - [ ] Fix any links in badges for CI and coverage to point to the new repository URL. 
-- [ ] Please check you have updated the package version to a post-review version and that you documented all changes in NEWS.md
+- [ ] Increment the package version to reflect the changes you made during review. In NEWS.md, add a heading for the new version and one bullet for each user-facing change, and each developer-facing change that you think is relevant.
 - [ ] We're starting to roll out software metadata files to all rOpenSci packages via the Codemeta initiative, see https://docs.ropensci.org/codemetar/for how to include it in your package, after installing the package - should be easy as running `codemetar::write_codemeta()` in the root of your package.
 
 Should you want to acknowledge your reviewers in your package DESCRIPTION, you can do so by making them [`"rev"`-type contributors in the `Authors@R` field](https://devguide.ropensci.org/building.html#authorship) (with their consent). 


### PR DESCRIPTION
This PR aims to clarify what authors should write in NEWS.md.

I note our request deviates from https://style.tidyverse.org/news.html
-- which focuses only on changes that face users -- and from
the practice of documenting changes after the first public
release. 

However, our approach is nice in that it leaves a record of the
peer-review that is more discoverable and readable than the
scattered comments in the review issue, where authors tell
reviewers how they addressed their requests.

I plan to follow up with a PR to the template in Spanish, but
to avoid working on a moving target, I suggest we discuss this
PR first.
﻿
