### PR TITLE
update readme editors list from airtable

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -132,7 +132,7 @@ cat(out, sep = "")
 ```
 
 
-### General editors
+### Editorial team
 
 ```{r editors, echo=FALSE}
 editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.))

--- a/README.Rmd
+++ b/README.Rmd
@@ -142,15 +142,9 @@ editors_all <- editors_all[order(last_names), ]
 
 editors_past <- editors_all[grep("Emeritus", editors_all$editor), ]
 editors <- editors_all[which(!editors_all$name %in% editors_past$name), ]
-editors_stats <- editors[grep("Statistics", editors$editor), ]
-# index of general editors plus hand-coded names of those who act as both
-# general and stats editors:
-eds_both <- c ("Adam Sparks")
-index <- which(!editors$name %in% editors_stats$name | editors$name %in% eds_both)
-editors <- editors[index, ]
 ```
 
-Our current team of editors for general software includes:
+Our current team of editors for software peer-review includes:
 
 ```{r gen_ed_out-fn, echo=FALSE}
 gen_ed_out <- function(ed_dat) {
@@ -163,14 +157,6 @@ gen_ed_out <- function(ed_dat) {
 ```
 ```{r editors-out, echo=FALSE, results='asis'}
 cat(gen_ed_out(editors), sep = "")
-```
-
-### Statistics editors
-
-Our current team of editors for statistical software includes:
-
-```{r editors-stats-out, echo=FALSE, results='asis'}
-cat(gen_ed_out(editors_stats), sep = "")
 ```
 
 ### Reviewers and former editors

--- a/README.Rmd
+++ b/README.Rmd
@@ -89,51 +89,63 @@ on how to improve the process on our [forum](https://discuss.ropensci.org/) and 
 
 ### Associate editors
 
-rOpenSci's Software Peer Review process is run by:
-
-* [Noam Ross](https://github.com/noamross), EcoHealth Alliance, USA;
-* [Karthik Ram](https://github.com/karthik), rOpenSci, USA;
-* [Maëlle Salmon](https://github.com/maelle), rOpenSci, France;
-* [Anna Krystalli](https://github.com/annakrystalli), University of Sheffield RSE, UK;
-* [Mauro Lepore](https://github.com/maurolepore), 2 Degrees Investing Initiative, USA;
-* [Laura DeCicco](https://github.com/ldecicco-USGS), USGS, USA;
-* [Julia Gustavsen](https://github.com/jooolia), Agroscope, Switzerland;
-* [Emily Riederer](https://github.com/emilyriederer), Capital One, USA;
-* [Adam Sparks](https://github.com/adamhsparks), Department of Primary Industries and Regional Development;
-* [Jeff Hollister](https://github.com/jhollist), US Environmental Protection Agency.
-
-Associate editors for statistical software are:
-
-- [Ben Bolker](https://github.com/bbolker), McMaster University, Canada;
-- [Rebecca Killick](https://github.com/rkillick), Lancaster University, UK;
-- [Stephanie Hicks](https://github.com/stephaniehicks), Johns Hopkins University, USA;
-- [Paula Moraga](https://github.com/Paula-Moraga), King Abdullah University of Science and Technology, Saudi Arabia;
-- [Leonardo Collado-Torres](https://github.com/lcolladotor), Lieber Institute for Brain Development, USA;
-- [Toby Hocking](https://github.com/tdhock), Northern Arizona University, USA.
-
-### Reviewers and guest editors
-
-We are grateful to the following individuals who have offered up their time and expertise to review packages submitted to rOpenSci.
-
-```{r reviewers, echo=FALSE, results='asis'}
+```{r editors, echo=FALSE, warning=FALSE}
 if (Sys.getenv("AIRTABLE_API_KEY") == ""){
   Sys.setenv(AIRTABLE_API_KEY = params$AIRTABLE_API_KEY)
 }
 if (Sys.getenv("AIRTABLE_ID") == ""){
   Sys.setenv(AIRTABLE_ID = params$AIRTABLE_ID)
 }
-editors <- c(
-  "Noam Ross", "Karthik Ram", "Maëlle Salmon",
-  "Anna Krystalli", "Mauro Lepore", 
-  "Laura DeCicco", "Julia Gustavsen",
-  "Emily Riederer", "Adam Sparks", "Jeff Hollister"
-  )
+
 reviewers <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"), 
                                 table = "reviewers-prod")
 reviewers <- reviewers$`reviewers-prod`$select_all()
+
+editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.))
+editors_all <- reviewers[which(editor_index_all), c("name", "github", "Affiliation", "editor")]
+last_names <- humaniformat::last_name(trimws(editors_all$name))
+editors_all <- editors_all[order(last_names), ]
+
+editors_past <- editors_all[grep("Emeritus", editors_all$editor), ]
+editors <- editors_all[which(!editors_all$name %in% editors_past$name), ]
+editors_stats <- editors[grep("Statistics", editors$editor), ]
+# index of general editors plus hand-coded names of those who act as both
+# general and stats editors:
+eds_both <- c ("Adam Sparks")
+index <- which(!editors$name %in% editors_stats$name | editors$name %in% eds_both)
+editors <- editors[index, ]
+```
+
+
+rOpenSci's Software Peer Review process is run our team of staff and volunteer editors. Current editors for general software are:
+
+```{r gen_ed_out-fn, echo=FALSE}
+gen_ed_out <- function(ed_dat) {
+    out <- gsub("(,\\sNA|\\s);", ";", paste0(
+        "- [", ed_dat$name, "](https://github.com/", ed_dat$github, "), ",
+        ed_dat$Affiliation, ";\n"))
+    out[length(out)] <- gsub(";\\n$", ".\n", out[length(out)])
+    return(out)
+}
+```
+```{r editors-out, echo=FALSE, results='asis'}
+cat(gen_ed_out(editors), sep = "")
+```
+
+Current editors for statistical software are:
+
+```{r editors-stats-out, echo=FALSE, results='asis'}
+cat(gen_ed_out(editors_stats), sep = "")
+```
+
+### Reviewers and former editors
+
+We are grateful to the following individuals who have offered up their time and expertise to review packages submitted to rOpenSci.
+
+```{r reviewers, echo=FALSE, results='asis'}
 reviewers <- reviewers[purrr::map_lgl(reviewers$reviews, 
                                ~!is.null(.)) & 
-                         !(reviewers$name %in% c(editors, "???")), ]
+                         !(reviewers$name %in% c(editors_all$name, "???")), ]
 # get last names
 last_names <- humaniformat::last_name(trimws(reviewers$name))
 reviewers <- reviewers[order(last_names), ]
@@ -141,18 +153,22 @@ reviewers$name[is.na(reviewers$name)] <- reviewers$github[is.na(reviewers$name)]
 cat(paste0("[", reviewers$name, "](https://github.com/", reviewers$github, ")", collapse = " \U00B7 "))
 ```
 
-We are also grateful to the following individuals who have served as guest editors.
+We are also grateful to the following individuals who have previously served as editors.
 
-```{r}
-#| echo: false
-#| results: 'asis'
+```{r editors_past, echo=FALSE, results='asis'}
+cat(gen_ed_out(editors_past), sep = "")
+```
+
+And the following who have served as guest editors.
+
+```{r guest-editors-out, echo=FALSE, results='asis'}
 guest_editors <- airtabler::airtable(base = "app8dssb6a7PG6Vwj", 
                                 table = "guest-editors")
 guest_editors <- guest_editors$`guest-editors`$select_all()
-guest_editors <- guest_editors[!(guest_editors$name %in% c(editors, "???")), ]
+guest_editors <- guest_editors[!(guest_editors$name %in% c(editors_all$name, "???")), ]
 # get last names
 last_names <- humaniformat::last_name(trimws(guest_editors$name))
 guest_editors <- guest_editors[order(last_names), ]
-cat(paste0("[", guest_editors$name, "](https://github.com/", guest_editors$github, ")", collapse = " \U00B7 "))
+cat(gen_ed_out(guest_editors), sep = "")
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,9 +87,9 @@ on how to improve the process on our [forum](https://discuss.ropensci.org/) and 
 
 # <a href="#editors" name="editors"></a> Editors and reviewers
 
-### Associate editors
+rOpenSci's Software Peer Review process is run our team of staff and volunteer editors and reviewers.
 
-```{r editors, echo=FALSE, warning=FALSE}
+```{r get-airtable-data, warning=FALSE, echo=FALSE}
 if (Sys.getenv("AIRTABLE_API_KEY") == ""){
   Sys.setenv(AIRTABLE_API_KEY = params$AIRTABLE_API_KEY)
 }
@@ -97,12 +97,46 @@ if (Sys.getenv("AIRTABLE_ID") == ""){
   Sys.setenv(AIRTABLE_ID = params$AIRTABLE_ID)
 }
 
-reviewers <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"), 
-                                table = "reviewers-prod")
-reviewers <- reviewers$`reviewers-prod`$select_all()
+at_eic <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"), 
+                              table = "editor-in-chief-rotation")
+eic <- at_eic$`editor-in-chief-rotation`$select_all()
 
+at_rev <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"), 
+                              table = "reviewers-prod")
+reviewers <- at_rev$`reviewers-prod`$select_all()
+
+aic_guest <- airtabler::airtable(base = "app8dssb6a7PG6Vwj", 
+                                 table = "guest-editors")
+guest_editors <- aic_guest$`guest-editors`$select_all()
+```
+
+### Editor-in-Chief
+
+```{r eic, echo=FALSE, results='asis'}
+eic$period_start <- as.Date(eic$period_start)
+eic$period_end <- as.Date(eic$period_end)
+today <- Sys.Date ()
+eic_now <- eic [which (eic$period_start <= today & eic$period_end >= today), ]
+eic_name <- eic_now$acting_aic_name [[1]]
+eic_id <- eic_now$acting_eic
+eic_in_rev_table <- which(reviewers$id == eic_id)
+eic_github <- reviewers$github[eic_in_rev_table]
+
+out <- paste0(
+    "We rotate our Editor-in-Chief, generally every three months. ",
+    "Our current Editor-in-Chief is [", eic_name, "](https://github.com/",
+    eic_github, ").\n"
+)
+cat(out, sep = "")
+```
+
+
+### General editors
+
+```{r editors, echo=FALSE}
 editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.))
 editors_all <- reviewers[which(editor_index_all), c("name", "github", "Affiliation", "editor")]
+editors_all <- editors_all [which(!editors_all$name == eic_name), ]
 last_names <- humaniformat::last_name(trimws(editors_all$name))
 editors_all <- editors_all[order(last_names), ]
 
@@ -116,8 +150,7 @@ index <- which(!editors$name %in% editors_stats$name | editors$name %in% eds_bot
 editors <- editors[index, ]
 ```
 
-
-rOpenSci's Software Peer Review process is run our team of staff and volunteer editors. Current editors for general software are:
+Our current team of editors for general software includes:
 
 ```{r gen_ed_out-fn, echo=FALSE}
 gen_ed_out <- function(ed_dat) {
@@ -132,7 +165,9 @@ gen_ed_out <- function(ed_dat) {
 cat(gen_ed_out(editors), sep = "")
 ```
 
-Current editors for statistical software are:
+### Statistics editors
+
+Our current team of editors for statistical software includes:
 
 ```{r editors-stats-out, echo=FALSE, results='asis'}
 cat(gen_ed_out(editors_stats), sep = "")
@@ -162,13 +197,9 @@ cat(gen_ed_out(editors_past), sep = "")
 And the following who have served as guest editors.
 
 ```{r guest-editors-out, echo=FALSE, results='asis'}
-guest_editors <- airtabler::airtable(base = "app8dssb6a7PG6Vwj", 
-                                table = "guest-editors")
-guest_editors <- guest_editors$`guest-editors`$select_all()
 guest_editors <- guest_editors[!(guest_editors$name %in% c(editors_all$name, "???")), ]
 # get last names
 last_names <- humaniformat::last_name(trimws(guest_editors$name))
 guest_editors <- guest_editors[order(last_names), ]
 cat(gen_ed_out(guest_editors), sep = "")
 ```
-

--- a/README.Rmd
+++ b/README.Rmd
@@ -117,7 +117,7 @@ eic$period_start <- as.Date(eic$period_start)
 eic$period_end <- as.Date(eic$period_end)
 today <- Sys.Date ()
 eic_now <- eic [which (eic$period_start <= today & eic$period_end >= today), ]
-eic_name <- eic_now$acting_aic_name [[1]]
+eic_name <- eic_now$acting_eic_name [[1]]
 eic_id <- eic_now$acting_eic
 eic_in_rev_table <- which(reviewers$id == eic_id)
 eic_github <- reviewers$github[eic_in_rev_table]

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,7 +87,7 @@ on how to improve the process on our [forum](https://discuss.ropensci.org/) and 
 
 # <a href="#editors" name="editors"></a> Editors and reviewers
 
-rOpenSci's Software Peer Review process is run our team of staff and volunteer editors and reviewers.
+rOpenSci's Software Peer Review process is run by our team of dedicated editors and reviewers.
 
 ```{r get-airtable-data, warning=FALSE, echo=FALSE}
 if (Sys.getenv("AIRTABLE_API_KEY") == ""){

--- a/README.Rmd
+++ b/README.Rmd
@@ -88,6 +88,7 @@ on how to improve the process on our [forum](https://discuss.ropensci.org/) and 
 # <a href="#editors" name="editors"></a> Editors and reviewers
 
 rOpenSci's Software Peer Review process is run by our team of dedicated editors and reviewers.
+Information on the current team, and the current status of software peer review, can be seen on our [interactive dashboard](https://ropensci-review-tools.github.io/dashboard/).
 
 ```{r get-airtable-data, warning=FALSE, echo=FALSE}
 if (Sys.getenv("AIRTABLE_API_KEY") == ""){

--- a/README.Rmd
+++ b/README.Rmd
@@ -184,7 +184,8 @@ cat(gen_ed_out(editors_past), sep = "")
 And the following who have served as guest editors.
 
 ```{r guest-editors-out, echo=FALSE, results='asis'}
-guest_editors <- guest_editors[!(guest_editors$name %in% c(editors_all$name, "???")), ]
+guest_editors <- guest_editors[!(guest_editors$name %in%
+    c(editors_all$name, eic_name, "???")), ]
 # get last names
 last_names <- humaniformat::last_name(trimws(guest_editors$name))
 guest_editors <- guest_editors[order(last_names), ]

--- a/README.Rmd
+++ b/README.Rmd
@@ -97,17 +97,17 @@ if (Sys.getenv("AIRTABLE_ID") == ""){
   Sys.setenv(AIRTABLE_ID = params$AIRTABLE_ID)
 }
 
-at_eic <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"), 
+at_eic <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"),
                               table = "editor-in-chief-rotation")
 eic <- at_eic$`editor-in-chief-rotation`$select_all()
 
-at_rev <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"), 
+at_rev <- airtabler::airtable(base = Sys.getenv("AIRTABLE_ID"),
                               table = "reviewers-prod")
 reviewers <- at_rev$`reviewers-prod`$select_all()
 
-aic_guest <- airtabler::airtable(base = "app8dssb6a7PG6Vwj", 
+at_guest <- airtabler::airtable(base = "app8dssb6a7PG6Vwj",
                                  table = "guest-editors")
-guest_editors <- aic_guest$`guest-editors`$select_all()
+guest_editors <- at_guest$`guest-editors`$select_all()
 ```
 
 ### Editor-in-Chief

--- a/README.md
+++ b/README.md
@@ -459,6 +459,5 @@ served as editors.
 
 And the following who have served as guest editors.
 
-- [Laura DeCicco](https://github.com/ldecicco-usgs),;
 - [Ana Laura Diedrichs](https://github.com/anadiedrichs),;
 - [Hao Zhu](https://github.com/haozhu233),.

--- a/README.md
+++ b/README.md
@@ -102,49 +102,54 @@ tracker](https://github.com/ropensci/software-review-meta/issues).
 
 # <a href="#editors" name="editors"></a> Editors and reviewers
 
-### Associate editors
+rOpenSci’s Software Peer Review process is run by our team of dedicated
+editors and reviewers.
 
-rOpenSci’s Software Peer Review process is run by:
+### Editor-in-Chief
 
-- [Noam Ross](https://github.com/noamross), EcoHealth Alliance, USA;
-- [Karthik Ram](https://github.com/karthik), rOpenSci, USA;
-- [Maëlle Salmon](https://github.com/maelle), rOpenSci, France;
-- [Anna Krystalli](https://github.com/annakrystalli), University of
-  Sheffield RSE, UK;
-- [Mauro Lepore](https://github.com/maurolepore), 2 Degrees Investing
-  Initiative, USA;
-- [Laura DeCicco](https://github.com/ldecicco-USGS), USGS, USA;
-- [Julia Gustavsen](https://github.com/jooolia), Agroscope, Switzerland;
-- [Emily Riederer](https://github.com/emilyriederer), Capital One, USA;
-- [Adam Sparks](https://github.com/adamhsparks), Department of Primary
-  Industries and Regional Development;
-- [Jeff Hollister](https://github.com/jhollist), US Environmental
-  Protection Agency.
+We rotate our Editor-in-Chief, generally every three months. Our current
+Editor-in-Chief is [Laura DeCicco](https://github.com/ldecicco-usgs).
 
-Associate editors for statistical software are:
+### General editors
 
-- [Ben Bolker](https://github.com/bbolker), McMaster University, Canada;
-- [Rebecca Killick](https://github.com/rkillick), Lancaster University,
-  UK;
-- [Stephanie Hicks](https://github.com/stephaniehicks), Johns Hopkins
-  University, USA;
-- [Paula Moraga](https://github.com/Paula-Moraga), King Abdullah
-  University of Science and Technology, Saudi Arabia;
-- [Leonardo Collado-Torres](https://github.com/lcolladotor), Lieber
-  Institute for Brain Development, USA;
+Our current team of editors for software peer-review includes:
+
+- [Julia Gustavsen](https://github.com/jooolia), Agroscope;
+- [Jouni Helske](https://github.com/helske), University of Jyväskylä,
+  Finland;
 - [Toby Hocking](https://github.com/tdhock), Northern Arizona
-  University, USA.
+  University, USA;
+- [Jeff Hollister](https://github.com/jhollist), US Environmental
+  Protection Agency;
+- [Rebecca Killick](https://github.com/rkillick), Lancaster University,
+  U.K.;
+- [Anna Krystalli](https://github.com/annakrystalli);
+- [Mauro Lepore](https://github.com/maurolepore), 2 Degrees Investing
+  Initiative;
+- [Beatriz Milz](https://github.com/beatrizmilz), University of Sao
+  Paulo - Institute of Energy and Environment;
+- [Emily Riederer](https://github.com/emilyriederer), Capital One;
+- [Francisco Rodriguez-Sanchez](https://github.com/Pakillo), Universidad
+  de Sevilla, Spain;
+- [Noam Ross](https://github.com/noamross), EcoHealth Alliance;
+- [Maëlle Salmon](https://github.com/maelle), rOpenSci;
+- [Margaret Siple](https://github.com/mcsiple), National Oceanic and
+  Atmospheric Administration;
+- [Adam Sparks](https://github.com/adamhsparks), DPIRD, East Perth, WA,
+  AUS;
+- [Emi Tanaka](https://github.com/emitanaka), Australian National
+  University.
 
-### Reviewers and guest editors
+### Reviewers and former editors
 
 We are grateful to the following individuals who have offered up their
 time and expertise to review packages submitted to rOpenSci.
 
 [Sam Albers](https://github.com/boshek) · [Toph
 Allen](https://github.com/toph-allen) · [Kaique dos S.
-Alves](https://github.com/AlvesKS) · [Brooke
-Anderson](https://github.com/geanders) · [Alison
-Appling](https://github.com/aappling-usgs) · [Zebulun
+Alves](https://github.com/AlvesKS) · [Alison
+Appling](https://github.com/aappling-usgs) · [Denisse Fierro
+Arcos](https://github.com/lidefi87) · [Zebulun
 Arendsee](https://github.com/arendsee) · [Taylor
 Arnold](https://github.com/statsmaths) · [Al-Ahmadgaid B.
 Asaad](https://github.com/alstat) · [Dean
@@ -176,30 +181,36 @@ Brown](https://github.com/eebrown) · [Julien
 Brun](https://github.com/brunj7) · [Jenny
 Bryan](https://github.com/jennybc) · [Lukas
 Burk](https://github.com/jemus42) · [Lorenzo
-Busetto](https://github.com/lbusett) · [Mario Gavidia
+Busetto](https://github.com/lbusett) · [Maria Paula
+Caldas](https://github.com/mpaulacaldas) · [Mario Gavidia
 Calderón](https://github.com/quishqa) · [Brad
-Cannell](https://github.com/brad-cannell) · [Kevin
-Cazelles](https://github.com/KevCaz) · [Scott
-Chamberlain](https://github.com/sckott) · [Cathy
+Cannell](https://github.com/brad-cannell) · [Joaquin
+Cavieres](https://github.com/jcavieresg) · [Kevin
+Cazelles](https://github.com/KevCaz) · [Cathy
 Chamberlin](https://github.com/chamberlinc) · [Jennifer
 Chang](https://github.com/j23414) · [Pierre
 Chausse](https://github.com/pchausse) · [Jorge
 Cimentada](https://github.com/cimentadaj) · [Nicholas
 Clark](https://github.com/nicholasjclark) · [Chase
 Clark](https://github.com/chasemc) · [Jon
-Clayden](https://github.com/jonclayden) · [Will
+Clayden](https://github.com/jonclayden) · [Dena Jane
+Clink](https://github.com/DenaJGibbon) · [Will
 Cornwell](https://github.com/wcornwell) · [Nic
 Crane](https://github.com/thisisnic) · [Enrico
-Crema](https://github.com/ercrema) · [Ildiko
-Czeller](https://github.com/czeildi) · [Kauê de
-Sousa](https://github.com/kauedesousa) · [Christophe
+Crema](https://github.com/ercrema) · [Verónica
+Cruz-Alonso](https://github.com/VeruGHub) · [Ildiko
+Czeller](https://github.com/czeildi) · [Tad
+Dallas](https://github.com/taddallas) · [Kauê de
+Sousa](https://github.com/kauedesousa) · [Laura
+DeCicco](https://github.com/ldecicco-usgs) · [Christophe
 Dervieux](https://github.com/cderv) · [Amanda
 Dobbyn](https://github.com/aedobbyn) · [Jasmine
 Dumas](https://github.com/jasdumas) · [Remko
 Duursma](https://github.com/RemkoDuursma) · [Mark
 Edmondson](https://github.com/MarkEdmondson1234) · [Paul
 Egeler](https://github.com/pegeler) · [Evan
-Eskew](https://github.com/eveskew) · [Salvador
+Eskew](https://github.com/eveskew) · [Harry
+Eslick](https://github.com/harryeslick) · [Salvador
 Fernandez](https://github.com/salvafern) · [Alexander
 Fischer](https://github.com/s3alfisc) · [Kim
 Fitter](https://github.com/kimnewzealand) · [Robert M
@@ -207,19 +218,25 @@ Flight](https://github.com/rmflight) · [Sydney
 Foks](https://github.com/sfoks) · [Stephen
 Formel](https://github.com/sformel-usgs) · [Zachary Stephen Longiaru
 Foster](https://github.com/zachary-foster) · [Auriel
-Fournier](https://github.com/aurielfournier) · [Carl
+Fournier](https://github.com/aurielfournier) · [Kaija
+Gahm](https://github.com/kaijagahm) · [Zach
+Gajewski](https://github.com/gzach93) · [Carl
 Ganz](https://github.com/carlganz) · [Duncan
-Garmonsway](https://github.com/nacnudus) · [Sharla
+Garmonsway](https://github.com/nacnudus) · [Jan Laurens
+Geffert](https://github.com/JanLauGe) · [Sharla
 Gelfand](https://github.com/sharlagelfand) · [Monica
 Gerber](https://github.com/monicagerber) · [Duncan
 Gillespie](https://github.com/dosgillespie) · [David
-Gohel](https://github.com/davidgohel) · [Rohit
+Gohel](https://github.com/davidgohel) · [A. Cagri
+gokcek](https://github.com/cagrigokcek) · [Guadalupe
+Gonzalez](https://github.com/guadag12) · [Rohit
 Goswami](https://github.com/HaoZeke) · [Laura
 Graham](https://github.com/laurajanegraham) · [Charles
 Gray](https://github.com/softloud) · [Matthias
 Grenié](https://github.com/Rekyt) · [Corinna
 Gries](https://github.com/cgries) · [Hugo
-Gruson](https://github.com/bisaloo) · [W Kyle
+Gruson](https://github.com/bisaloo) · [Ernest
+Guevarra](https://github.com/ernestguevarra) · [W Kyle
 Hamilton](https://github.com/kylehamilton) · [Ivan
 Hanigan](https://github.com/ivanhanigan) · [Jeffrey
 Hanson](https://github.com/jeffreyhanson) · [Rayna
@@ -243,7 +260,8 @@ Hurr](https://github.com/bhive01) · [Ger
 Inberg](https://github.com/ginberg) · [Christopher
 Jackson](https://github.com/chjackson) · [Najko
 Jahn](https://github.com/njahn82) · [Tamora D
-James](https://github.com/tdjames1) · [Mike
+James](https://github.com/tdjames1) · [Veronica
+Jimenez-Jacinto](https://github.com/vjimenez9) · [Mike
 Johnson](https://github.com/mikejohnson51) · [Will
 Jones](https://github.com/wjones127) · [Max
 Joseph](https://github.com/mbjoseph) · [Megha
@@ -257,7 +275,8 @@ Kariyawasam](https://github.com/Tinula-kariyawasam) · [Hazel
 Kavılı](https://github.com/UniversalTourist) · [Jonathan
 Keane](https://github.com/jonkeane) · [Christopher T.
 Kenny](https://github.com/christopherkenny) · [Os
-Keyes](https://github.com/Ironholds) · [Aaron A.
+Keyes](https://github.com/Ironholds) · [Eunseop
+Kim](https://github.com/markean) · [Aaron A.
 King](https://github.com/kingaa) · [Michael
 Koontz](https://github.com/mikoontz) · [Bianca
 Kramer](https://github.com/bmkramer) · [Will
@@ -265,14 +284,17 @@ Landau](https://github.com/wlandau) · [Sam
 Lapp](https://github.com/sammlapp) · [Erin
 LeDell](https://github.com/ledell) · [Thomas
 Leeper](https://github.com/leeper) · [Sam
-Levin](https://github.com/levisc8) · [Stephanie
+Levin](https://github.com/levisc8) · [Lisa
+Levinson](https://github.com/lisalevinson) · [Stephanie
 Locke](https://github.com/stephlocke) · [Marion
 Louveaux](https://github.com/marionlouveaux) · [Robin
 Lovelace](https://github.com/robinlovelace) · [Julia Stewart
 Lowndes](https://github.com/jules32) · [Tim
-Lucas](https://github.com/timcdlucas) · [Andrew
+Lucas](https://github.com/timcdlucas) · [Muralidhar,
+M.A.](https://github.com/Kattuvan) · [Andrew
 MacDonald](https://github.com/aammd) · [Jesse
-Maegan](https://github.com/kierisi) · [Tristan
+Maegan](https://github.com/kierisi) · [Mike
+Mahoney](https://github.com/mikemahoney218) · [Tristan
 Mahr](https://github.com/tjmahr) · [Paula Andrea
 Martinez](https://github.com/orchid00) · [Joao
 Martins](https://github.com/zambujo) · [Ben
@@ -282,28 +304,30 @@ McBain](https://github.com/milesmcbain) · [Lucy D’Agostino
 McGowan](https://github.com/LucyMcGowan) · [Amelia
 McNamara](https://github.com/AmeliaMN) · [Elaine
 McVey](https://github.com/eamcvey) · [Bryce
-Mecum](https://github.com/amoeba) · [François
+Mecum](https://github.com/amoeba) · [Nolwenn Le
+Meur](https://github.com/nolwenn) · [François
 Michonneau](https://github.com/fmichonneau) · [Mario
 Miguel](https://github.com/leocadio-miguel) · [Helen
-Miller](https://github.com/helenmiller16) · [Beatriz
-Milz](https://github.com/beatrizmilz) · [Jessica
+Miller](https://github.com/helenmiller16) · [Jessica
 Minnier](https://github.com/jminnier) · [Priscilla
 Minotti](https://github.com/pmnatural) · [Nichole
 Monhait](https://github.com/nmonhait) · [Kelsey
-Montgomery](https://github.com/kelshmo) · [Paula
-Moraga](https://github.com/Paula-Moraga) · [Ross
+Montgomery](https://github.com/kelshmo) · [Natalia
+Morandeira](https://github.com/nmorandeira) · [Ross
 Mounce](https://github.com/rossmounce) · [Athanasia Monika
 Mowinckel](https://github.com/drmowinckels) · [Lincoln
 Mullen](https://github.com/lmullen) · [Matt
 Mulvahill](https://github.com/mmulvahill) · [Maria Victoria
 Munafó](https://github.com/mvickm) · [David
 Neuzerling](https://github.com/mdneuzerling) · [Dillon
-Niederhut](https://github.com/deniederhut) · [Rory
+Niederhut](https://github.com/deniederhut) · [Joel
+Nitta](https://github.com/joelnitta) · [Rory
 Nolan](https://github.com/rorynolan) · [Kari
 Norman](https://github.com/karinorman) · [Jakub
 Nowosad](https://github.com/Nowosad) · [Matt
 Nunes](https://github.com/nunesmatt) · [Daniel
-Nüst](https://github.com/nuest) · [Joseph
+Nüst](https://github.com/nuest) · [Lauren
+O’Brien](https://github.com/obrl-soil) · [Joseph
 O’Brien](https://github.com/jmobrien) · [Paul
 Oldham](https://github.com/poldham) · [Samantha
 Oliver](https://github.com/limnoliver) · [Dan
@@ -314,12 +338,15 @@ Ottolinger](https://github.com/ottlngr) · [Mark
 Padgham](https://github.com/mpadge) · [Marina
 Papadopoulou](https://github.com/marinapapa) · [Edzer
 Pebesma](https://github.com/edzer) · [Thomas Lin
-Pedersen](https://github.com/thomasp85) · [Marcelo S.
+Pedersen](https://github.com/thomasp85) · [Antonio J.
+Pérez-Luque](https://github.com/ajpelu) · [Marcelo S.
 Perlin](https://github.com/msperlin) · [Rafael
 Pilliard-Hellwig](https://github.com/rtaph) · [Rodrigo Neto
 Pires](https://github.com/bozaah) · [Lindsay
 Platt](https://github.com/lindsayplatt) · [Nicholas
-Potter](https://github.com/potterzot) · [Etienne
+Potter](https://github.com/potterzot) · [Joanne
+Potts](https://github.com/TheAnalyticalEdge) · [Josep
+Pueyo-Ros](https://github.com/jospueyo) · [Etienne
 Racine](https://github.com/etiennebr) · [Manuel
 Ramon](https://github.com/manuramon) · [Nistara
 Randhawa](https://github.com/nistara) · [David
@@ -328,13 +355,16 @@ Read](https://github.com/qdread) · [Neal
 Richardson](https://github.com/nealrichardson) · [tyler
 rinker](https://github.com/trinker) · [Emily
 Robinson](https://github.com/robinsones) · [David
-Robinson](https://github.com/dgrtwo) · [Francisco
-Rodriguez-Sanchez](https://github.com/Pakillo) · [Julia
+Robinson](https://github.com/dgrtwo) · [Alec
+Robitaille](https://github.com/robitalec) · [Sam
+Rogers](https://github.com/rogerssam) · [Julia
 Romanowska](https://github.com/jromanowska) · [Xavier
 Rotllan-Puig](https://github.com/xavi-rp) · [Bob
 Rudis](https://github.com/hrbrmstr) · [Edgar
 Ruiz](https://github.com/edgararuiz) · [Kent
-Russel](https://github.com/timelyportfolio) · [Alicia
+Russel](https://github.com/timelyportfolio) · [Michael
+Sachs](https://github.com/sachsmc) · [Sheila
+Saia](https://github.com/sheilasaia) · [Alicia
 Schep](https://github.com/AliciaSchep) · [Klaus
 Schliep](https://github.com/KlausVigo) · [Clemens
 Schmid](https://github.com/nevrome) · [Patrick
@@ -342,11 +372,11 @@ Schratz](https://github.com/pat-s) · [Collin
 Schwantes](https://github.com/collinschwantes) · [Marco
 Sciaini](https://github.com/marcosci) · [Heidi
 Seibold](https://github.com/HeidiSeibold) · [Julia
-Silge](https://github.com/juliasilge) · [Margaret
-Siple](https://github.com/mcsiple) · [Peter
+Silge](https://github.com/juliasilge) · [Peter
 Slaughter](https://github.com/gothub) · [Mike
 Smith](https://github.com/grimbough) · [Tuija
-Sonkkila](https://github.com/tts) · [Jemma
+Sonkkila](https://github.com/tts) · [Øystein
+Sørensen](https://github.com/osorensen) · [Jemma
 Stachelek](https://github.com/jsta) · [Christine
 Stawitz](https://github.com/ChristineStawitz-NOAA) · [Irene
 Steves](https://github.com/isteves) · [Kelly
@@ -355,16 +385,17 @@ Strimas-Mackey](https://github.com/mstrimas) · [Alex
 Stringer](https://github.com/awstringer1) · [Michael
 Sumner](https://github.com/mdsumner) · [Chung-Kai
 Sun](https://github.com/cksun-usc) · [Sarah
-Supp](https://github.com/sarahsupp) · [Emi
-Tanaka](https://github.com/emitanaka) · [Jason
+Supp](https://github.com/sarahsupp) · [Jason
 Taylor](https://github.com/jmt2080ad) · [Filipe
 Teixeira](https://github.com/FilipeamTeixeira) · [Andy
 Teucher](https://github.com/ateucher) · [Jennifer
 Thompson](https://github.com/jenniferthompson) · [Joe
-Thorley](https://github.com/joethorley) · [Tiffany
+Thorley](https://github.com/joethorley) · [Nicholas
+Tierney](https://github.com/njtierney) · [Tiffany
 Timbers](https://github.com/ttimbers) · [Tan
 Tran](https://github.com/vinhtantran) · [Tim
-Trice](https://github.com/timtrice) · [Kyle
+Trice](https://github.com/timtrice) · [Utku
+Turk](https://github.com/utkuturk) · [Kyle
 Ueyama](https://github.com/khueyama) · [Ted
 Underwood](https://github.com/tedunderwood) · [Adithi R.
 Upadhya](https://github.com/adithirgis) · [Kevin
@@ -377,7 +408,8 @@ Wagner](https://github.com/jacobpwagner) · [Ben
 Ward](https://github.com/BenJWard) · [Elin
 Waring](https://github.com/elinw) · [Rachel
 Warnock](https://github.com/rachelwarnock) · [Leah
-Wasser](https://github.com/lwasser) · [Lukas
+Wasser](https://github.com/lwasser) · [David
+Watkins](https://github.com/wdwatkins) · [Lukas
 Weber](https://github.com/lmweber) · [Marc
 Weber](https://github.com/mhweber) · [Karissa
 Whiting](https://github.com/karissawhiting) · [Stefan
@@ -389,7 +421,8 @@ Winter](https://github.com/dwinter) · [Sebastian
 Wójcik](https://github.com/SebastianWojcik86) · [Witold
 Wolski](https://github.com/wolski) · [Kara
 Woo](https://github.com/karawoo) · [Marvin N.
-Wright](https://github.com/mnwright) · [Bruna
+Wright](https://github.com/mnwright) · [Jacob
+Wujciak-Jens](https://github.com/assignUser) · [Bruna
 Wundervald](https://github.com/brunaw) · [Lauren
 Yamane](https://github.com/layamane) · [Emily
 Zabor](https://github.com/zabore) · [Taras
@@ -401,17 +434,29 @@ Zwart](https://github.com/jzwart) ·
 [santikka](https://github.com/santikka) ·
 [Bri](https://github.com/BriannaLind) ·
 [Flury](https://github.com/romanflury) ·
+[Vincent](https://github.com/vincentvanhees) ·
 [eholmes](https://github.com/eholmes) ·
 [Pachá](https://github.com/pachadotdev) ·
 [Rich](https://github.com/richfitz) ·
 [Claudia](https://github.com/cvitolo) ·
 [Jasmine](https://github.com/laijasmine) ·
-[Lluís](https://github.com/llrs) ·
+[Zack](https://github.com/zackarno) · [Lluís](https://github.com/llrs) ·
 [becarioprecario](https://github.com/becarioprecario) ·
 [gaurav](https://github.com/soodoku)
 
-We are also grateful to the following individuals who have served as
-guest editors.
+We are also grateful to the following individuals who have previously
+served as editors.
 
-[Ana Laura Diedrichs](https://github.com/anadiedrichs) · [Hao
-Zhu](https://github.com/haozhu233)
+- [Brooke Anderson](https://github.com/geanders);
+- [Scott Chamberlain](https://github.com/sckott);
+- [Paula Moraga](https://github.com/Paula-Moraga), King Abdullah
+  University of Science and Technology (KAUST), Saudi Arabia;
+- [Karthik Ram](https://github.com/karthik), University of California,
+  Berkeley, rOpenSci;
+- [Melina Vidoni](https://github.com/melvidoni).
+
+And the following who have served as guest editors.
+
+- [Laura DeCicco](https://github.com/ldecicco-usgs),;
+- [Ana Laura Diedrichs](https://github.com/anadiedrichs),;
+- [Hao Zhu](https://github.com/haozhu233),.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ tracker](https://github.com/ropensci/software-review-meta/issues).
 # <a href="#editors" name="editors"></a> Editors and reviewers
 
 rOpenSci’s Software Peer Review process is run by our team of dedicated
-editors and reviewers.
+editors and reviewers. Information on the current team, and the current
+status of software peer review, can be seen on our [interactive
+dashboard](https://ropensci-review-tools.github.io/dashboard/).
 
 ### Editor-in-Chief
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ dashboard](https://ropensci-review-tools.github.io/dashboard/).
 We rotate our Editor-in-Chief, generally every three months. Our current
 Editor-in-Chief is [Laura DeCicco](https://github.com/ldecicco-usgs).
 
-### General editors
+### Editorial team
 
 Our current team of editors for software peer-review includes:
 


### PR DESCRIPTION
@noamross @maelle Our editors list on the README was out of date. Because it was hand-coded :scream:  This PR now automates the editors list, with small rearrangements of other text.