### PR TITLE
rm eic from list of former guest editors

### DIFF
--- a/scripts/airtable-get-data.R
+++ b/scripts/airtable-get-data.R
@@ -47,7 +47,7 @@ guest_editors <- at_guest$`guest-editors`$select_all()
 guest_editors <- airtabler::airtable(base = "app8dssb6a7PG6Vwj",
                                 table = "guest-editors")
 guest_editors <- guest_editors$`guest-editors`$select_all(fields = list("name", "github"))
-guest_editors <- guest_editors[!(guest_editors$name %in% c(editors$name, "???")), ]
+guest_editors <- guest_editors[!(guest_editors$name %in% c(editors$name, eic_name, "???")), ]
 last_names <- humaniformat::last_name(trimws(guest_editors$name))
 guest_editors <- guest_editors[order(last_names), ]
 


### PR DESCRIPTION
@maelle Current README has this at the bottom:
![image](https://github.com/user-attachments/assets/770042f2-5d20-498d-afa2-5cc7d368d1e7)

And that's because that final list filters out editors, but that editors list is previously made by filtering out current eic:
https://github.com/ropensci/software-review/blob/bdc5997163413ad3eb3ce8f6d93f4e298afb2831/scripts/airtable-get-data.R#L38

This fixes, and should just remove current EiC from final list of "former guest editors"