### PR TITLE
Fix instructions on how to link a pre-submission issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/F-submit-statistical-software-for-review.md
+++ b/.github/ISSUE_TEMPLATE/F-submit-statistical-software-for-review.md
@@ -48,7 +48,7 @@ Language: <!--language-->en<!--end-language-->
 
 ## Pre-submission Inquiry
 
-- [ ] A pre-submission inquiry has been approved in [issue#<issue_num>](#<issue_num>)<!--Replace #<issue_num> with the issue number of the Pres-submission inquiry-->
+- [ ] A pre-submission inquiry has been approved in [issue#<issue_num>](https://github.com/ropensci/software-review/issues/<issue_num>)<!--Replace <issue_num> with the issue number of the Pres-submission inquiry-->
 
 
 ## General Information


### PR DESCRIPTION
Surprisingly the instructions currently on main lead to an unexpected URL

EXAMPLES

- https://github.com/ropensci/software-review/issues/791

  - uses: `[issue#767](#767)`
  - link: `https://github.com/ropensci/software-review/issues/791#767`

- https://github.com/ropensci/software-review/issues/747

  - uses: `[issue#727](#727)`
  - link: `https://github.com/ropensci/software-review/issues/747#727`

- https://github.com/ropensci/software-review/issues/769
  - uses: `[issue#<739>](#<739>)`
  - link: `https://github.com/ropensci/software-review/issues/769#<739>`

Feel free to change the markdown code to whatever you prefer and works.