### PR TITLE
Label pre-submissions as such

### DIFF
--- a/.github/ISSUE_TEMPLATE/B-submit-a-presubmission-inquiry.md
+++ b/.github/ISSUE_TEMPLATE/B-submit-a-presubmission-inquiry.md
@@ -2,6 +2,7 @@
 name: Submit a presubmission inquiry
 about: Not sure your software fits, or submitting a statistical package? Use this template to get a quick response from
   the editors
+labels: "0/presubmission"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
+++ b/.github/ISSUE_TEMPLATE/E-proponer-software-para-revision.md
@@ -1,6 +1,7 @@
 ---
 name: Preguntar si el software está dentro del alcance de rOpenSci
 about: ¿Quieres confirmar que tu paquete encaja en una revisión, o quieres enviar un paquete estadistico? Usa esta plantilla para obtener una repuesta por parte del equipo editorial en Español (Experimental)
+labels: "0/presubmission"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/J-Enviar-consulta-pré-submissão.md
+++ b/.github/ISSUE_TEMPLATE/J-Enviar-consulta-pré-submissão.md
@@ -1,6 +1,7 @@
 ---
 name: Enviar uma consulta de pré-submissão
 about: Não tem certeza de que seu software se encaixa ou está enviando um pacote estatístico? Use este modelo para obter uma resposta rápida dos editores
+labels: "0/presubmission"
 
 ---
 


### PR DESCRIPTION
This PR ensures new pre-submission issues are labelled as such. Thanks @yabellini for the idea.

---

Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository


